### PR TITLE
More Sussex testing fixes.

### DIFF
--- a/core/serial_command.py
+++ b/core/serial_command.py
@@ -121,6 +121,7 @@ class SerialCommand(object):
 
         # Send a reset, to ensure the RTS is set to false
         self.reset()
+        self.disable_external_trigger()
 
         # Send a clear channel command, just in case
         self.clear_channel()
@@ -131,7 +132,8 @@ class SerialCommand(object):
 
     def __del__(self):
         """Deletion function"""
-        self.reset()
+        self.disable_external_trigger()
+        self.clear_channel()
         if self._serial:
             self._send_command(_cmd_disable_ext_trig) # Stop accecpting external trigs
             self._serial.close()

--- a/orca_side/orca_run_script.py
+++ b/orca_side/orca_run_script.py
@@ -36,12 +36,15 @@ if __name__=="__main__":
 		    mean = -1 
 	            rms = -1
                     chan = args.channel
+
     	except xmlrpclib.Fault, e:
 	    # Attempt a safe stop and inform in the return type as to the success?
 	    tellie_server.stop()
     except xmlrpclib.Fault, e:
         # Attempt a safe stop and inform in the return type as to the success?
         tellie_server.stop()
+    tellie_server.stop()
+    tellie_server.clear_channel()
     print "Chan %s Mean %f RMS %f" %(chan,mean,rms)
         
 

--- a/orca_side/orca_run_script_slave.py
+++ b/orca_side/orca_run_script_slave.py
@@ -23,7 +23,6 @@ if __name__=="__main__":
         # TODO:
         # Parameter checks need to be performed here
         # But feedback needed for user (e.g. exact pulse number may not be possible)
-	#tellie_server.reset()
         tellie_server.select_channel(args.channel)
         tellie_server.set_pulse_number(int(args.pulse_number))
         tellie_server.set_trigger_delay(int(args.trigger_delay))
@@ -48,6 +47,8 @@ if __name__=="__main__":
         # Attempt a safe stop and inform in the return type as to the success?
         print "Exception %s " % e
         tellie_server.stop()
+    tellie_server.stop()
+    tellie_server.clear_channel()
     print "Chan %s Mean %f RMS %f" %(chan,mean,rms)
         
 


### PR DESCRIPTION
Instead of resetting we can just clear the channel, also added delay when we readout the buffer as sometimes it is not written when the python code tries to read it.