### PR TITLE
Use TELLIE in any directory

### DIFF
--- a/common/parameters.py
+++ b/common/parameters.py
@@ -5,11 +5,19 @@
 
 import math
 import sys
+import os
 import ConfigParser
 
 # Read config file
 config = ConfigParser.ConfigParser()
-config.readfp(open('tellie.cfg'))
+# Search PYTHONPATH for tellie.cfg
+paths = os.environ['PYTHONPATH'].split(os.pathsep)
+for path in paths:
+    try:
+        config.readfp(open(path+'/tellie.cfg'))
+        break
+    except:
+        continue
 
 # Connection to host
 _serial_port = str(config.get('CONNECTION', 'serial_port'))

--- a/core/tellie_server.py
+++ b/core/tellie_server.py
@@ -361,7 +361,7 @@ class SerialCommand(object):
         buffer_check = p._cmd_fire_series
         #if the series is less than 0.5 seconds, also check for the end of sequence
         if (self._current_pulse_number * self._current_pulse_delay) < 500:
-            buffer_check += _buffer_end_sequence
+            buffer_check += p._buffer_end_sequence
             self._send_command(p._cmd_fire_series, buffer_check=buffer_check)
         else:
             self._send_command(p._cmd_fire_series, buffer_check=buffer_check)
@@ -441,7 +441,7 @@ class SerialCommand(object):
         self.log_phrase("Read PINOUT", 0, _snotDaqLog)
         #if in firing mode, check the buffer shows the sequence has ended
         if self._firing:
-            if self.read_buffer() == _buffer_end_sequence:
+            if self.read_buffer() == p._buffer_end_sequence:
                 print "K in buffer"
                 self._firing = False
             else:


### PR DESCRIPTION
Searches python path for tellie.cfg instead of cwd. Needed for when you are using tellie in other directories e.g. doing channel calibrations, PMT calibrations etc.