### PR TITLE
Bugfix when reading the pins and the PIC chip is still writing.

### DIFF
--- a/core/tellie_server.py
+++ b/core/tellie_server.py
@@ -516,8 +516,24 @@ class SerialCommand(object):
         if len(numbers) == 0:
             self.log_phrase("Sequence doesn't appear to have finished..", 0, _snotDaqLog)
             return None
-        elif len(numbers) == 2:
+        #If we only get one number it is likely the PIC hasnt finished writing to the buffer
+        if len(numbers) == 1:
+            #Wait a bit longer and then read out the buffer again
+            time.sleep(p._short_pause)
+            outputNew = self.read_buffer()
+            #Combine the two buffer outputs and try to parse the PIN readings
+            output += outputNew
+            numbers =  output.split()
+        if len(numbers) == 2:
             try:
+                #The RMS is written to 6 decimal places so check that the PIC chip has written the PIN reading completely
+                if len(numbers[1].split(".")[-1]) < 6:
+                    #Wait a bit longer and then read out the buffer again
+                    time.sleep(p._short_pause)
+                    outputNew = self.read_buffer()
+                    output += outputNew
+                    numbers =  output.split()
+
                 pin = float(numbers[0])
                 rms = float(numbers[1])
             except:

--- a/core/tellie_server.py
+++ b/core/tellie_server.py
@@ -524,6 +524,11 @@ class SerialCommand(object):
             #Combine the two buffer outputs and try to parse the PIN readings
             output += outputNew
             numbers =  output.split()
+            #If we still dont get two numbers after waiting to read out the buffer again log an error and return None
+            if len(numbers) == 1:
+                self.log_phrase("Unable to convert numbers to floats Numbers: %s Buffer: %s",str(numbers),output, 2, _snotDaqLog)
+                return None
+        
         if len(numbers) == 2:
             try:
                 #The RMS is written to 6 decimal places so check that the PIC chip has written the PIN reading completely

--- a/core/tellie_server.py
+++ b/core/tellie_server.py
@@ -527,7 +527,7 @@ class SerialCommand(object):
         if len(numbers) == 2:
             try:
                 #The RMS is written to 6 decimal places so check that the PIC chip has written the PIN reading completely
-                while len(numbers[1].split(".")[-1]) < 6:
+                if len(numbers[1].split(".")[-1]) < 6:
                     #Wait a bit longer and then read out the buffer again
                     time.sleep(p._short_pause)
                     outputNew = self.read_buffer()

--- a/core/tellie_server.py
+++ b/core/tellie_server.py
@@ -525,8 +525,8 @@ class SerialCommand(object):
             output += outputNew
             numbers =  output.split()
             #If we still dont get two numbers after waiting to read out the buffer again log an error and return None
-            if len(numbers) == 1:
-                self.log_phrase("Unable to parse more than one number when reading PIN from buffer. Numbers: %s Buffer: %s",str(numbers),output, 2, _snotDaqLog)
+            if len(numbers) != 2:
+                self.log_phrase("Unable to parse two numbers when reading PIN from buffer. Numbers: %s Buffer: %s",str(numbers),output, 2, _snotDaqLog)
                 return None
         
         if len(numbers) == 2:

--- a/core/tellie_server.py
+++ b/core/tellie_server.py
@@ -526,7 +526,7 @@ class SerialCommand(object):
             numbers =  output.split()
             #If we still dont get two numbers after waiting to read out the buffer again log an error and return None
             if len(numbers) == 1:
-                self.log_phrase("Unable to convert numbers to floats Numbers: %s Buffer: %s",str(numbers),output, 2, _snotDaqLog)
+                self.log_phrase("Unable to parse more than one number when reading PIN from buffer. Numbers: %s Buffer: %s",str(numbers),output, 2, _snotDaqLog)
                 return None
         
         if len(numbers) == 2:

--- a/core/tellie_server.py
+++ b/core/tellie_server.py
@@ -527,7 +527,7 @@ class SerialCommand(object):
         if len(numbers) == 2:
             try:
                 #The RMS is written to 6 decimal places so check that the PIC chip has written the PIN reading completely
-                if len(numbers[1].split(".")[-1]) < 6:
+                while len(numbers[1].split(".")[-1]) < 6:
                     #Wait a bit longer and then read out the buffer again
                     time.sleep(p._short_pause)
                     outputNew = self.read_buffer()


### PR DESCRIPTION
Sometimes when we try to make a PIN reading the PIC chip hasn't finished writing to the buffer, so we only get part of the PIN reading. This bugfix makes the server wait for 0.1 seconds if it doesn't get a complete PIN reading. After the wait the code reads out the buffer again appending it to whatever we already had. 

